### PR TITLE
feat: add transparent background

### DIFF
--- a/components/controls/background-controls.tsx
+++ b/components/controls/background-controls.tsx
@@ -78,7 +78,7 @@ export function BackgroundControls() {
               type="text"
               value={backgroundColor}
               onChange={(e) => handleBackgroundChange(e.target.value, "custom")}
-              className="w-22 font-mono uppercase"
+              className="w-26 font-mono uppercase"
             />
           </div>
         </div>

--- a/components/controls/material-controls.tsx
+++ b/components/controls/material-controls.tsx
@@ -238,7 +238,7 @@ export function MaterialControls() {
               type="text"
               value={customColor}
               onChange={(e) => setCustomColor(e.target.value)}
-              className="w-22 font-mono uppercase"
+              className="w-26 font-mono uppercase"
             />
           </div>
         </div>

--- a/components/ui/color-picker.tsx
+++ b/components/ui/color-picker.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef, useState, useEffect } from "react";
-import { HexColorPicker } from "react-colorful";
+import { HexAlphaColorPicker } from "react-colorful";
 import { createPortal } from "react-dom";
 
 const useClickOutside = (
@@ -95,7 +95,7 @@ export const PopoverPicker = ({ color, onChange }: PopoverPickerProps) => {
             ref={popoverRef}
             className="fixed z-[9999] rounded-lg shadow-lg"
             style={{ top: position.y, left: position.x }}>
-            <HexColorPicker color={color} onChange={onChange} />
+            <HexAlphaColorPicker color={color} onChange={onChange} />
           </div>,
           document.body,
         )}


### PR DESCRIPTION
Adds the option to pick an alpha value in the color picker and apply it to the canvas (needs to set the alpha clear color for this)